### PR TITLE
update esprima version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/klei/ng-dependencies"
   },
   "dependencies": {
-    "esprima": "^1.2.2",
+    "esprima": "^2.6.0",
     "estraverse": "^1.5.1",
     "lodash": "^3.0.1"
   },


### PR DESCRIPTION
Update esprima version to support ES6.

e.g: When using arrow functions, return error in parsing: "Unexpected token =>"