### PR TITLE
update estraverse to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "esprima": "^2.6.0",
-    "estraverse": "^1.5.1",
+    "estraverse": "^4.2.0",
     "lodash": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This makes ng-dependencies support more ES2015 features.

The particular one I stumbled upon is this one : `const [, decimalPart = ''] = ...`. estraverse 1.x chokes on this syntax with this message: `Unknown node type AssignmentPattern`.

I could not find a changelog for estraverse describing what exactly are the breaking changes between v1 and v4. The test suite for ng-dependencies passes without modification.