### PR TITLE
support module names that are in variables

### DIFF
--- a/test/index_test.js
+++ b/test/index_test.js
@@ -101,4 +101,16 @@ describe('lookup', function () {
     };
     lookup(source).should.eql(deps);
   });
+
+  it('should capture simple module declaration using a variable instead of a literal module name', function () {
+    var source = 'var moduleName = "test"; angular.module(moduleName, []);';
+    var deps = {
+      dependencies: ['ng'],
+      modules: {
+        'test': []
+      }
+    };
+    lookup(source).should.eql(deps);
+  });
+
 });


### PR DESCRIPTION
Makes `ng-dependencies` support the following situation:

```
var moduleName = 'my-module';

angular.module(moduleName, []);
```

I know it's quite a (very?) rare case but turns out it would be useful to me. Would you be willing to merge this?