### PR TITLE
fix crash on uninitialized variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function findDependencies(source, opts) {
 
   estraverse.traverse(esprima.parse(source, {sourceType: "module"}), {
     leave: function(node, parent) {
-      if (canBeModuleNameVariable(node)) {
+      if (canBeModuleNameVariableDeclaration(node)) {
         potentialModuleNameVariable[node.id.name] = node.init.value;
       }
 
@@ -70,8 +70,8 @@ function isNgModuleDeclaration(node) {
   return node.type === 'CallExpression' && node.callee.name === 'angularModule' && node.arguments.length > 0 && node.arguments[0].value === 'ng';
 }
 
-function canBeModuleNameVariable(node) {
-  return node.type === 'VariableDeclarator' && typeof node.init.value === 'string';
+function canBeModuleNameVariableDeclaration(node) {
+  return node.type === 'VariableDeclarator' && node.init && typeof node.init.value === 'string';
 }
 
 module.exports = findDependencies;

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -113,4 +113,9 @@ describe('lookup', function () {
     lookup(source).should.eql(deps);
   });
 
+  it('should not crash on uninitialized variables', function () {
+    var source = 'var uninitializedVar;';
+    lookup(source);
+  });
+
 });


### PR DESCRIPTION
Bug introduced in #15. See https://github.com/klei/ng-dependencies/pull/15#discussion_r73729294. Thanks to @noXi89 for reporting it.
